### PR TITLE
Add instructions to run the kernel as a shaded jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,33 @@ If (and only if) IEpsilon detects no usage of the println() function, it automat
 IEpsilon is a fully-functional EOL kernel, maintaining the state of variables and defined operations across cell executions as is the standard.
 
 ![IEpsilon supports all of EOL](https://user-images.githubusercontent.com/48567303/221294505-554ea352-1447-45ce-b773-70f0684301b0.gif)
+
+## How to test the kernel locally
+
+1. Clone the repository and run `mvn package`. This generates a shaded jar with all the required dependencies.
+2. Create a new kernel in your python installation, which must include `jupyter` (e.g. Anaconda does this):
+
+```bash
+python -m ipykernel install --user --name=epsilon --display-name "epsilon"
+```
+
+3. The previous step would create a default notebook in a concrete directory in your system. That directory has a `kernel.json` configuration file whose contents you have to change with these ones (notice that you have to update the `path` to the shaded jar with the one in your system, by indicating where the sources of this repo are present):
+
+```json
+{
+    "argv": [
+        "java",
+        "-jar",
+        "<path-to-this-repository-sources>/target/IEpsilonPrototype-1.0-SNAPSHOT.jar",
+        "{connection_file}"
+    ],
+    "display_name": "Epsilon",
+    "env": {},
+    "interrupt_mode": "message",
+    "language": "eol"
+}
+```
+
+4. You can check that there is a new `epsilon` kernel available in your system by running `jupyter kernelspec list`
+
+5. Now, in any folder, run `jupyter notebook` to start a jupyter server, where you will be able to create new notebooks, and select the `epsilon` kernel for interpreting the cells content.

--- a/pom.xml
+++ b/pom.xml
@@ -39,5 +39,30 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>main</mainClass>
+                        </transformer>
+                    </transformers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 
 </project>


### PR DESCRIPTION
This PR allows running the Epsilon kernel as a fat jar through the use of maven shade plugin.

It also adds instructions at the end of the `README` file on how to install the kernel locally.